### PR TITLE
Update/0.13.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "statsmodels" %}
-{% set version = "0.13.2" %}
+{% set version = "0.13.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,18 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/statsmodels-{{ version }}.tar.gz
-  sha256: 77dc292c9939c036a476f1770f9d08976b05437daa229928da73231147cde7d4
+  sha256: 593526acae1c0fda0ea6c48439f67c3943094c542fe769f8b90fe9e6c6cc4871
 
 build:
   number: 0
   skip: true  # [py<37] 
-  script:
-    - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"                # [not win]
-    - "rm -f ${PREFIX}/LICENSE.txt"                                                    # [not win]
-    - "rm -f ${PREFIX}/setup.cfg"                                                      # [not win]
-    - python setup.py install --single-version-externally-managed --record record.txt  # [win]
-    - "del /f /q %PREFIX%\\LICENSE.txt"                                                 # [win]
-    - "del /f /q %PREFIX%\\setup.cfg"                                                   # [win]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
@@ -26,17 +20,17 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.29.22
-    - numpy >=1.19
-    - scipy >=1.3
+    - numpy
+    - cython
     - setuptools
+    - setuptools_scm >=7.0,<8
     - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - scipy >=1.3
     - packaging >=21.3
-    - pandas >=1.0
+    - pandas >=0.25
     - patsy >=0.5.2
 
 test:
@@ -50,7 +44,7 @@ test:
 about:
   home: https://www.statsmodels.org
   license: BSD-3-Clause
-  license_file: INSTALL.txt
+  license_file: LICENSE.txt
   license_family: BSD
   summary: Statistical computations and models for use with SciPy
   dev_url: https://github.com/statsmodels/statsmodels

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,11 @@ requirements:
     - python
     - pip
     - numpy
+    - scipy
     - cython >=0.29.32
     - setuptools
     - setuptools_scm >=7.0,<8
+    - toml
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - pip
     - numpy
-    - cython
+    - cython >=0.29.32
     - setuptools
     - setuptools_scm >=7.0,<8
     - wheel


### PR DESCRIPTION
Changes:
- Update from 0.13.2 to 0.13.5
- Revert to base setup
- Remove pinnings in host
- Add setuptools_scm in host
- Correct pandas req in run
- Correct license file 

https://github.com/statsmodels/statsmodels/compare/v0.13.2...v0.13.5
https://github.com/statsmodels/statsmodels/releases
https://github.com/statsmodels/statsmodels/blob/v0.13.5/pyproject.toml
https://github.com/statsmodels/statsmodels/blob/v0.13.5/requirements.txt
https://github.com/statsmodels/statsmodels/blob/v0.13.5/setup.py

(Note: statsmodels define numpy restrictions which are not set in the recipe. However these restrictions are for compatibility with scipy. This will be handled for us by the dependency of scipy on specific numpy versions.)

https://anaconda.atlassian.net/browse/PKG-1019