### PR TITLE
[PKG-2306] statsmodels 0.14.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,58 +1,55 @@
 {% set name = "statsmodels" %}
-{% set version = "0.13.5" %}
+{% set version = "0.14.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/statsmodels-{{ version }}.tar.gz
-  sha256: 593526acae1c0fda0ea6c48439f67c3943094c542fe769f8b90fe9e6c6cc4871
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6875c7d689e966d948f15eb816ab5616f4928706b180cf470fd5907ab6f647a4
 
 build:
-  number: 1
-  skip: true  # [py<37] 
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
     - python
+    - cython 0.29.32
+    - numpy {{ numpy }}
     - pip
-    # scipy needs 1.23 on python 3.11
-    - numpy 1.23         # [py==311]
-    - numpy {{ numpy }}  # [py!=311]
     - scipy
-    - cython >=0.29.32
     - setuptools
-    - setuptools_scm >=7.0,<8
+    - setuptools_scm 7.0.4
     - toml
     - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - scipy >=1.3
     - packaging >=21.3
-    - pandas >=0.25
+    - pandas >=1.0
     - patsy >=0.5.2
+    - scipy >=1.4,!=1.9.2
 
 test:
+  imports:
+    - statsmodels
   requires:
     - pip
   commands:
     - pip check
-  imports:
-    - statsmodels
 
 about:
   home: https://www.statsmodels.org
+  dev_url: https://github.com/statsmodels/statsmodels
+  doc_url: https://www.statsmodels.org/stable/
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD
   summary: Statistical computations and models for use with SciPy
-  dev_url: https://github.com/statsmodels/statsmodels
-  doc_url: https://www.statsmodels.org/stable/
   description: |
     Statsmodels is a Python module that allows users to explore data, estimate
     statistical models, and perform statistical tests. An extensive list of
@@ -60,7 +57,6 @@ about:
     statistics are available for different types of data and each estimator.
     Researchers across fields may find that statsmodels fully meets their
     needs for statistical computing and data analysis in Python.
-  doc_source_url: https://github.com/statsmodels/statsmodels/blob/master/docs/source/index.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - cython 0.29.32
     - numpy {{ numpy }}
     - pip
-    - scipy
+    - scipy 1.10.1
     - setuptools
     - setuptools_scm 7.0.4
     - toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - cython 0.29.32
+    - cython >=0.29.26,<3
     - numpy {{ numpy }}
     - pip
     - scipy 1.10.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
     - scipy 1.10.1
     - setuptools
-    - setuptools_scm 7.0.4
+    - setuptools_scm >=7.0,<8
     - toml
     - wheel
   run:


### PR DESCRIPTION
Changelog: https://www.statsmodels.org/devel/release/version0.14.0.html
License: https://github.com/statsmodels/statsmodels/blob/v0.14.0/LICENSE.txt
Requirements: 
- https://github.com/statsmodels/statsmodels/blob/v0.14.0/INSTALL.txt
- https://www.statsmodels.org/devel/install.html
- https://github.com/statsmodels/statsmodels/blob/v0.14.0/pyproject.toml
- https://github.com/statsmodels/statsmodels/blob/v0.14.0/requirements.txt
- https://github.com/statsmodels/statsmodels/blob/v0.14.0/setup.py

Actions:
1. Clean up the recipe:
- Remove skipping `py<37`
- Add flags `--no-build-isolation` to `script`
- Fix `numpy` in `host`
2. Use exact `setuptools_scm 7.0.4` in host, https://github.com/statsmodels/statsmodels/blob/6909efdd638390bd6079ca30d313b99344770180/pyproject.toml#L12
3. Update pinnings in `run` for `scipy` and `pandas`
4. Sort `host` and `run` dependencies
5. Remove `doc_source_url`

Notes:
- `plotnine 0.12.1` requires `statsmodels 0.14.0`, see https://github.com/has2k1/plotnine/blob/5ee0ed60b1341107ab80cc50d564721cbffda3a4/pyproject.toml#L32