### PR TITLE
V0.14.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/patsy-feedstock/pr7/3da7fda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,9 @@ requirements:
   host:
     - python
     - cython >=3.0.10,<4
-    - numpy {{ numpy }}
+    - numpy >=1.23
     - pip
-    - scipy 1.10.1 # [py!=312]
-    - scipy 1.11.3 # [py==312]
+    - scipy >=1.13,<2
     - setuptools
     - setuptools_scm >=8.0,<9
     - toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - cython >=3.0.10,<4
     - numpy 1.23  # [py<311]
-    - numpy {{ numpy }}
+    - numpy {{ numpy }}  # [py>=311]
     - pip
     - scipy >=1.13,<2
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,22 +19,23 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - cython >=0.29.26,<3
+    - cython >=3.0.10,<4
     - numpy {{ numpy }}
     - pip
-    - scipy 1.10.1 # [py!=312]
-    - scipy 1.11.3 # [py==312]
+    - scipy>=1.13,<2
+    # - scipy 1.10.1 # [py!=312]
+    # - scipy 1.11.3 # [py==312]
     - setuptools
-    - setuptools_scm >=7.0,<8
+    - setuptools_scm >=8.0,<9
     - toml
     - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - packaging >=21.3
-    - pandas >=1.0
-    - patsy >=0.5.2
-    - scipy >=1.4,!=1.9.2
+    - pandas >=1.4,!=2.1.0
+    - patsy >=0.5.6
+    - scipy >=1.8,!=1.9.2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,8 @@ requirements:
     - cython >=3.0.10,<4
     - numpy {{ numpy }}
     - pip
-    - scipy>=1.13,<2
-    # - scipy 1.10.1 # [py!=312]
-    # - scipy 1.11.3 # [py==312]
+    - scipy 1.10.1 # [py!=312]
+    - scipy 1.11.3 # [py==312]
     - setuptools
     - setuptools_scm >=8.0,<9
     - toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 890550147ad3a81cda24f0ba1a5c4021adc1601080bd00e191ae7cd6feecd6ad
 
 build:
+  skip: True  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,8 @@ requirements:
   host:
     - python
     - cython >=3.0.10,<4
-    - numpy >=1.23
+    - numpy 1.23  # [py<311]
+    - numpy {{ numpy }}
     - pip
     - scipy >=1.13,<2
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "statsmodels" %}
-{% set version = "0.14.0" %}
+{% set version = "0.14.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6875c7d689e966d948f15eb816ab5616f4928706b180cf470fd5907ab6f647a4
+  sha256: 890550147ad3a81cda24f0ba1a5c4021adc1601080bd00e191ae7cd6feecd6ad
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4940](https://anaconda.atlassian.net/browse/PKG-4940)
- [Upstream repository](https://github.com/statsmodels/statsmodels/tree/v0.14.2)
- [Upstream changelog/diff](https://www.statsmodels.org/devel/release/version0.14.2.html)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/patsy-feedstock/pull/7

### Explanation of changes:

- Set version and sha256
- Add python version skip
- Update dependencies


[PKG-4940]: https://anaconda.atlassian.net/browse/PKG-4940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ