### PR TITLE
statsmodels 0.14.2 1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/patsy-feedstock/pr7/3da7fda


### PR DESCRIPTION
Same as https://github.com/AnacondaRecipes/statsmodels-feedstock/pull/8 with the `abs.yaml` removed