### PR TITLE
v0.14.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "statsmodels" %}
-{% set version = "0.14.2" %}
+{% set version = "0.14.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 890550147ad3a81cda24f0ba1a5c4021adc1601080bd00e191ae7cd6feecd6ad
+  sha256: 5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67
 
 build:
   skip: True  # [py<39]
@@ -20,17 +20,16 @@ requirements:
   host:
     - python
     - cython >=3.0.10,<4
-    - numpy 1.23  # [py<311]
-    - numpy {{ numpy }}  # [py>=311]
+    - numpy 2
     - pip
     - scipy >=1.13,<2
-    - setuptools
+    - setuptools >=69.0.2
     - setuptools_scm >=8.0,<9
-    - toml
+    # - toml
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy  >=1.22.3,<3
     - packaging >=21.3
     - pandas >=1.4,!=2.1.0
     - patsy >=0.5.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - scipy >=1.13,<2
     - setuptools >=69.0.2
     - setuptools_scm >=8.0,<9
-    # - toml
     - wheel
   run:
     - python


### PR DESCRIPTION
statsmodels 0.14.2

**Destination channel:**  defaults

### Links

- [PKG-4647]() 
- [Upstream repository](https://github.com/statsmodels/statsmodels/tree/v0.14.4)
- [Upstream changelog/diff](https://github.com/statsmodels/statsmodels/releases/tag/v0.14.4)
- [build reqs](https://github.com/statsmodels/statsmodels/blob/v0.14.4/pyproject.toml)
- [run deps](https://github.com/statsmodels/statsmodels/blob/v0.14.4/requirements.txt)

### Explanation of changes:

- Build for python 3.13
- Use numpy2 


[PKG-4647]: https://anaconda.atlassian.net/browse/PKG-4647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ