### PR TITLE
update to 0.14.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "statsmodels" %}
-{% set version = "0.14.4" %}
+{% set version = "0.14.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: de260e58cccfd2ceddf835b55a357233d6ca853a1aa4f90f7553a52cc71c6ddf
 
 build:
-  skip: True  # [py<39]
+  skip: true  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -20,12 +20,11 @@ requirements:
   host:
     - python
     - cython >=3.0.10,<4
-    - numpy 2
+    - numpy {{ numpy }}
     - pip
     - scipy >=1.13,<2
     - setuptools >=69.0.2
     - setuptools_scm >=8.0,<9
-    - wheel
   run:
     - python
     - numpy  >=1.22.3,<3


### PR DESCRIPTION
statsmodels 0.14.5

**Destination channel:**  defaults

### Links

- [PKG-8993](https://anaconda.atlassian.net/browse/PKG-8993) 
- [Upstream repository](https://github.com/statsmodels/statsmodels/tree/v0.14.5)
- [Upstream changelog/diff](https://github.com/statsmodels/statsmodels/releases/tag/v0.14.5)
- [build reqs](https://github.com/statsmodels/statsmodels/blob/v0.14.5/pyproject.toml)
- [run deps](https://github.com/statsmodels/statsmodels/blob/v0.14.5/requirements.txt)

### Explanation of changes:

- Latest version is compatible with scipy 1.16


[PKG-8993]: https://anaconda.atlassian.net/browse/PKG-8993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ